### PR TITLE
Release PSPersonio v0.1.4

### DIFF
--- a/PSPersonio/PSPersonio.psd1
+++ b/PSPersonio/PSPersonio.psd1
@@ -3,7 +3,7 @@
     RootModule         = 'PSPersonio.psm1'
 
     # Version number of this module.
-    ModuleVersion      = '0.1.3'
+    ModuleVersion      = '0.1.4'
 
     # ID used to uniquely identify this module
     GUID               = 'd12fa74a-f464-41fc-a4a6-2bf9d9f9c0fa'

--- a/PSPersonio/changelog.md
+++ b/PSPersonio/changelog.md
@@ -1,4 +1,9 @@
 ﻿# Changelog
+## 0.1.4 (2023-07-11)
+ - Fix:
+    - Personio.Absence.AbsencePeriod: \
+    Fix wrong type definition on member "DaysCount". Previously, it was an \[int\], actually it is a \[float\]
+
 ## 0.1.3 (2023-06-28)
  - Upd:
     - Connect-Personio: Starting June 2023 Personio decides to step away from JWT tokens and began to invent a service specific token format. This update handles both behaviours.\

--- a/PSPersonio/xml/PSPersonio.Types.ps1xml
+++ b/PSPersonio/xml/PSPersonio.Types.ps1xml
@@ -193,10 +193,10 @@
             <ScriptProperty>
                 <Name>DaysCount</Name>
                 <GetScriptBlock>
-                    [int]::Parse( $this.BaseObject.days_count )
+                    [float]::Parse( $this.BaseObject.days_count )
                 </GetScriptBlock>
                 <SetScriptBlock>
-                    $this.BaseObject.days_count = $args[0]
+                    $this.BaseObject.days_count = [float]$args[0]
                 </SetScriptBlock>
             </ScriptProperty>
 


### PR DESCRIPTION
# 0.1.4 (2023-07-11)
 - Fix:
    - Personio.Absence.AbsencePeriod: \
    Fix wrong type definition on member "DaysCount". Previously, it was an \[int\], actually it is a \[float\]
