### PR TITLE
Release PSPersonio v0.1.4.1

### DIFF
--- a/PSPersonio/PSPersonio.psd1
+++ b/PSPersonio/PSPersonio.psd1
@@ -3,7 +3,7 @@
     RootModule         = 'PSPersonio.psm1'
 
     # Version number of this module.
-    ModuleVersion      = '0.1.4'
+    ModuleVersion      = '0.1.4.1'
 
     # ID used to uniquely identify this module
     GUID               = 'd12fa74a-f464-41fc-a4a6-2bf9d9f9c0fa'

--- a/PSPersonio/changelog.md
+++ b/PSPersonio/changelog.md
@@ -1,4 +1,10 @@
 ﻿# Changelog
+## 0.1.4.1 (2023-07-13)
+ - Fix:
+    - Personio.Absence.AbsencePeriod: \
+    Fix wrong type definition on member "DaysCount". Now, it is \[System.Decimal\]
+
+
 ## 0.1.4 (2023-07-11)
  - Fix:
     - Personio.Absence.AbsencePeriod: \

--- a/PSPersonio/xml/PSPersonio.Types.ps1xml
+++ b/PSPersonio/xml/PSPersonio.Types.ps1xml
@@ -193,10 +193,10 @@
             <ScriptProperty>
                 <Name>DaysCount</Name>
                 <GetScriptBlock>
-                    [float]::Parse( $this.BaseObject.days_count )
+                    [System.Decimal]$this.BaseObject.days_count
                 </GetScriptBlock>
                 <SetScriptBlock>
-                    $this.BaseObject.days_count = [float]$args[0]
+                    $this.BaseObject.days_count = [System.Decimal]$args[0]
                 </SetScriptBlock>
             </ScriptProperty>
 


### PR DESCRIPTION
# 0.1.4.1 (2023-07-13)
 - Fix:
    - Personio.Absence.AbsencePeriod: \
    Fix wrong type definition on member "DaysCount". Now, it is \[System.Decimal\]